### PR TITLE
remove :fetchAt keys from database on checkEmptyQueue

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -280,6 +280,7 @@ async function checkEmptyQueue (queue) {
       await this.redis
         .multi()
         .srem(`${this.namespace}:active`, queue)
+        .del(`${this.namespace}:active:${queue}:fetchAt`)
         .exec()
     } else {
       await this.redis.unwatch()

--- a/test/worker.js
+++ b/test/worker.js
@@ -327,6 +327,21 @@ describe('Worker', () => {
       assert.equal(await r.scard('test:active'), 0)
     })
 
+    it('should delete fetchAt when clearing empty queues from active list', async () => {
+      const m = queues.createManager({ namespace: 'test', redis: r })
+      await m.push('my:queue', 0)
+
+      let count = 0
+
+      const w = queues.createWorker({ namespace: 'test', redis: r, checkEmptyIterations: 1 }, async (queue, [job]) => {
+        count++
+      })
+
+      await w.drain()
+      assert.equal(count, 1)
+      assert.equal(await r.get('test:active:my:queue:fetchAt'), null)
+    })
+
     it('should emit an error when job data is missing', async () => {
       const m = queues.createManager({ namespace: 'test', redis: r })
       const jobId = await m.push('my:queue', 0)


### PR DESCRIPTION
It seems that helper keys `:fetchAt` are never removed from redis, even when queue is removed from main `:active:` list

Example - https://prnt.sc/mhsuyu - list of redis keys here was logged out once per second.